### PR TITLE
change dataset access order to avoid memory issue

### DIFF
--- a/Fine_Tune_XLSR_Wav2Vec2_on_Turkish_ASR_with_🤗_Transformers.ipynb
+++ b/Fine_Tune_XLSR_Wav2Vec2_on_Turkish_ASR_with_🤗_Transformers.ipynb
@@ -10031,7 +10031,7 @@
         "outputId": "8b91a977-2559-4adc-8298-b4ad6b7ff196"
       },
       "source": [
-        "input_dict = processor(common_voice_test[\"input_values\"][0], return_tensors=\"pt\", padding=True)\n",
+        "input_dict = processor(common_voice_test[0][\"input_values\"], return_tensors=\"pt\", padding=True)\n",
         "\n",
         "logits = model(input_dict.input_values.to(\"cuda\")).logits\n",
         "\n",
@@ -10104,7 +10104,7 @@
         "print(processor.decode(pred_ids))\n",
         "\n",
         "print(\"\\nReference:\")\n",
-        "print(common_voice_test_transcription[\"sentence\"][0].lower())\n"
+        "print(common_voice_test_transcription[0][\"sentence\"].lower())\n"
       ],
       "execution_count": null,
       "outputs": [


### PR DESCRIPTION
@patrickvonplaten 

Just a very simple change to avoid memory issue, like

```
common_voice_test["input_values"][0] -> common_voice_test[0]["input_values"]
```