### PR TITLE
Update Boosting_Wav2Vec2_with_n_grams_in_Transformers.ipynb

### DIFF
--- a/Boosting_Wav2Vec2_with_n_grams_in_Transformers.ipynb
+++ b/Boosting_Wav2Vec2_with_n_grams_in_Transformers.ipynb
@@ -6089,9 +6089,9 @@
       "cell_type": "code",
       "source": [
         "!pip install https://github.com/kpu/kenlm/archive/master.zip \n",
-        "!pyctcdecode==0.3.0\n",
-        "!pip install datasets=2.0.0\n",
-        "!pip transformers==4.18.0"
+        "!pip install pyctcdecode==0.3.0\n",
+        "!pip install datasets==2.0.0\n",
+        "!pip install transformers==4.18.0"
       ],
       "metadata": {
         "id": "OWGc_zfyq5_T",


### PR DESCRIPTION
Corrected pip installs to resolve notebook errors.